### PR TITLE
model: Make Administrator extend User

### DIFF
--- a/src/model/Administrator.java
+++ b/src/model/Administrator.java
@@ -3,7 +3,7 @@ package model;
 /**
  * Created by XinZhang on 9/27/16.
  */
-public class Administrator {
+public class Administrator extends Manager {
     private String username;
     private String password;
     public Administrator() {


### PR DESCRIPTION
This makes registration logic much easier because any user created
regardless of type chosen will be of type User. I realize that we didn't
originally intend to encourage administrators to create reports etc.
with their administrator accounts, but I don't see the harm in allowing
it. They are administrators, after all — they have root anyway.

@xzhang9292 
