### PR TITLE
DataSource: Create single instance statically

### DIFF
--- a/src/model/DataSource.java
+++ b/src/model/DataSource.java
@@ -13,12 +13,11 @@ import java.util.Set;
  * Created by NikosD on 9/28/16.
  */
 public class DataSource {
-    private static DataSource instance;
+    private static DataSource instance = new DataSource();
     private Set<User> users;
 
 
     private DataSource() {
-        instance = new DataSource();
         users = new HashSet<>();
     }
 

--- a/src/model/DataSource.java
+++ b/src/model/DataSource.java
@@ -50,7 +50,7 @@ public class DataSource {
      */
     public void add(User userdata) throws InvalidUserException {
         for (User userOb : users) {
-            if (userdata.user.equals(userOb.user)) {
+            if (userdata.getUser().equals(userOb.getUser())) {
                 throw new InvalidUserException("Invalid ID");
             }
         }

--- a/src/model/User.java
+++ b/src/model/User.java
@@ -25,6 +25,10 @@ public class User {
         this.password = password;
     }
 
+    public String getUser() {
+        return user;
+    }
+
     public boolean authenticate(String user, String password) {
         return this.user.equals(user) && this.password.equals(password);
     }


### PR DESCRIPTION
Instead of assigning DataSource.instance = new DataSource() in the
constructor (which causes a stack overflow), assign the new instance
statically. This way, DataSource.getInstance() will never return a null
pointer as it currently does.
